### PR TITLE
chore: fix turbostat name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ It collects CPU and core statistics using the `turbostat` tool and exposes them 
 
 ## How to use
 
-You can download the binaries for available platforms in the [Releases](https://github.com/BlackDark/prometheus_turbotstat_exporter/releases).
+You can download the binaries for available platforms in the [Releases](https://github.com/BlackDark/prometheus_turbostat_exporter/releases).
 
 - Run with `turbostat-exporter`. Default listener on `0.0.0.0:9101` (also displayed as logs),
 - or run with docker (but must be run as priviliged to have all information available):
-  `docker run -p 9101:9101 --privileged ghcr.io/blackdark/prometheus_turbotstat_exporter:main`
+  `docker run -p 9101:9101 --privileged ghcr.io/blackdark/prometheus_turbostat_exporter:main`
 
 
 ## Example scrape output

--- a/main.go
+++ b/main.go
@@ -587,7 +587,7 @@ func main() {
 }
 
 func startServer() {
-	fmt.Println("Prometheus turbostat exporter - created by BlackDark (https://github.com/BlackDark/prometheus_turbotstat_exporter)")
+	fmt.Println("Prometheus turbostat exporter - created by BlackDark (https://github.com/BlackDark/prometheus_turbostat_exporter)")
 	parseConfiguration()
 
 	reader := executeProgram(0)


### PR DESCRIPTION
Sorry. :)
The repository description also needs to be corrected.

Issue: https://github.com/BlackDark/prometheus_turbostat_exporter/issues/3

Interesting fact: you can read the state from a file `/sys/kernel/debug/pmc_core/package_cstate_show`.